### PR TITLE
fix: navigation link highlight duplication fixed

### DIFF
--- a/src/app/shared/components/main-nav/main-nav.component.html
+++ b/src/app/shared/components/main-nav/main-nav.component.html
@@ -11,9 +11,23 @@
         </button>
       </mat-toolbar>
       <mat-nav-list class="nav-list">
-        <a *ngFor="let link of links" class="nav-link" mat-list-item [routerLink]="link.route" [routerLinkActive]="['active']" (click)="drawer.toggle()">{{link.name}}</a>
-        <span *ngIf="roleLinks.length" class="separator"></span>
-        <a *ngFor="let link of roleLinks" class="nav-link" mat-list-item [routerLink]="link.route" [routerLinkActive]="['active']" (click)="drawer.toggle()">{{link.name}}</a>
+        <a *ngFor="let link of userLinks" 
+          class="nav-link" 
+          mat-list-item 
+          [routerLink]="link.route" 
+          [routerLinkActive]="['active']" 
+          [routerLinkActiveOptions]="{ exact: true }" 
+          (click)="drawer.toggle()"
+        >{{link.name}}</a>
+        <span *ngIf="adminLinks.length" class="separator"></span>
+        <a *ngFor="let link of adminLinks" 
+          class="nav-link" 
+          mat-list-item 
+          [routerLink]="link.route" 
+          [routerLinkActive]="['active']" 
+          [routerLinkActiveOptions]="{ exact: true }" 
+          (click)="drawer.toggle()"
+        >{{link.name}}</a>
       </mat-nav-list>
       <button type="button" class="logout-btn" (click)="logout(); drawer.toggle()">Выйти</button>
     </div>

--- a/src/app/shared/components/main-nav/main-nav.component.ts
+++ b/src/app/shared/components/main-nav/main-nav.component.ts
@@ -22,8 +22,8 @@ import { Observable, finalize, take } from 'rxjs';
 export class MainNavComponent implements OnInit {
   @Select(AuthState.isAuthenticated) isAuthenticated$!: Observable<boolean>;
   @Select(AuthState.user) user$!: Observable<User>;
-  public links: NavigationLink[] = [];
-  public roleLinks: NavigationLink[] = [];
+  public userLinks: NavigationLink[] = [];
+  public adminLinks: NavigationLink[] = [];
 
   constructor(
     private readonly authService: AuthService,
@@ -35,8 +35,8 @@ export class MainNavComponent implements OnInit {
     this.user$.pipe(untilDestroyed(this)).subscribe((user: User) => {
       const role = user?.role.name;
 
-      this.links = <NavigationLink[]>navLinksMap.get(UserRole.user);
-      this.roleLinks = role && role !== UserRole.user ? <NavigationLink[]>navLinksMap.get(role) : [];
+      this.userLinks = <NavigationLink[]>navLinksMap.get(UserRole.user);
+      this.adminLinks = role && role !== UserRole.user ? <NavigationLink[]>navLinksMap.get(role) : [];
     });
   }
 


### PR DESCRIPTION
Fixed navigation link highlight duplication via adding the option for the router link { exact: true }.